### PR TITLE
Added support for child devices with Outlet and Underbed Light

### DIFF
--- a/SleepNumberController_Driver.groovy
+++ b/SleepNumberController_Driver.groovy
@@ -174,11 +174,11 @@ def manageChildren() {
 }
 
 def getOutlet() {
-    return childDevices.find({it.deviceNetworkId == getChildDNI("outlet")})
+    return getChildDevice(getChildDNI("outlet"))
 }
 
 def getUnderbed() {
-    return childDevices.find({it.deviceNetworkId == getChildDNI("underbedlight")})
+    return getChildDevice(getChildDNI("underbedlight"))
 }
 
 

--- a/SleepNumberController_Driver.groovy
+++ b/SleepNumberController_Driver.groovy
@@ -107,7 +107,7 @@ metadata {
       input name: "footWarmerLevel", type: "enum", title: "Warmer level for 'on'", description: "Only valid for device type that is 'foot warmer'", options: HEAT_TEMPS.collect{ it.key }, defaultValue: "Medium"
       input name: "footWarmerTimer", type: "enum", title: "Warmer duration for 'on'", description: "Only valid for device type that is 'foot warmer'", options: HEAT_TIMES.collect{ it.key }, defaultValue: "30m"
       input name: "enableSleepData", type: "bool", title: "Enable sleep data collection", defaultValue: false
-      input name: "enableChildDevices", type: "bool", title: "Enable child devices for switches", defaultValue: false
+      input name: "enableChildDevices", type: "bool", title: "Enable child devices for switches (Presence device only)", defaultValue: false
     }
   }
 }
@@ -143,27 +143,33 @@ def updated() {
   poll()
 }
 
+def uninstalled() {
+   deleteChildDevice(getChildDNI("outlet"))
+   deleteChildDevice(getChildDNI("underbedlight"))
+}
 
 def manageChildren() {
-    def outlet = getOutlet()
-    if (!outlet) {
-        outlet = addChildDevice('hubitat','Generic Component Switch', getChildDNI("outlet"),
-            	                     [ label: getChildName("Outlet"),
-                                      componentName: "outlet",
-                                      componentLabel: getChildName("Outlet"),
-                	                  isComponent:true,
-                                      completedSetup:true])
-	    log.info("Created Outlet child device")
-    }
-    def underbed = getUnderbed()
-    if (!underbed) {
-        outlet = addChildDevice('hubitat','Generic Component Switch', getChildDNI("underbedlight"),
-            	                     [ label: getChildName("Underbed Light"),
-                                      componentName: "underbedlight",
-                                      componentLabel: getChildName("Underbed Light"),
-                	                  isComponent:true,
-                                      completedSetup:true])
-	    log.info("Created Underbed light child device")
+    switch (state.type) {
+        case "presence":
+            def outlet = getOutlet()
+            if (!outlet) {
+                outlet = addChildDevice('hubitat','Generic Component Switch', getChildDNI("outlet"),
+                                        [ label: getChildName("Outlet"),
+                                         componentName: "outlet",
+                                         componentLabel: getChildName("Outlet"),                	                  
+                                         completedSetup:true])
+                log.info("Created Outlet child device")
+            }
+            def underbed = getUnderbed()
+            if (!underbed) {
+                outlet = addChildDevice('hubitat','Generic Component Switch', getChildDNI("underbedlight"),
+                                        [ label: getChildName("Underbed Light"),
+                                         componentName: "underbedlight",
+                                         componentLabel: getChildName("Underbed Light"),                	                  
+                                         completedSetup:true])
+                log.info("Created Underbed light child device")
+            }
+            break
     }
 }
 

--- a/SleepNumberController_Driver.groovy
+++ b/SleepNumberController_Driver.groovy
@@ -154,19 +154,13 @@ def manageChildren() {
             def outlet = getOutlet()
             if (!outlet) {
                 outlet = addChildDevice('hubitat','Generic Component Switch', getChildDNI("outlet"),
-                                        [ label: getChildName("Outlet"),
-                                         componentName: "outlet",
-                                         componentLabel: getChildName("Outlet"),                	                  
-                                         completedSetup:true])
+                                        [ label: getChildName("Outlet")])
                 log.info("Created Outlet child device")
             }
             def underbed = getUnderbed()
             if (!underbed) {
                 outlet = addChildDevice('hubitat','Generic Component Switch', getChildDNI("underbedlight"),
-                                        [ label: getChildName("Underbed Light"),
-                                         componentName: "underbedlight",
-                                         componentLabel: getChildName("Underbed Light"),                	                  
-                                         completedSetup:true])
+                                        [ label: getChildName("Underbed Light")])
                 log.info("Created Underbed light child device")
             }
             break


### PR DESCRIPTION
Here is a PR with some basic support for child devices. In my case, I wanted to include the Underbed Lights in a Scene. I can't do this without a proper switch device in Hubitat, so the child comes in handy. Feel free to not use this in your production code if it does not fit your direction / style etc!

I only did Outlet and Underbed Light for now with basic on/off control. We could certainly add more to this same pattern for other aspects of the bed. 